### PR TITLE
Add workflow to sync milestones to releases repo

### DIFF
--- a/.github/workflows/notify-milestone.yml
+++ b/.github/workflows/notify-milestone.yml
@@ -1,0 +1,20 @@
+name: Notify releases repo
+
+on:
+  milestone:
+    types: [created, edited]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to releases repo
+        env:
+          GH_TOKEN: ${{ secrets.MM_RELEASES_SYNC_TOKEN }}
+        run: |
+          gh api repos/MerginMaps/releases/dispatches \
+            --method POST \
+            -f event_type=milestone-${{ github.event.action }} \
+            -f 'client_payload[repo]=${{ github.repository }}' \
+            -f 'client_payload[milestone_title]=${{ github.event.milestone.title }}' \
+            -f 'client_payload[milestone_url]=${{ github.event.milestone.html_url }}'


### PR DESCRIPTION
This new CI action syncs milestones with releases tickets. It opens one when a new milestone is created and renames existing ones when a milestone is renamed.