### PR TITLE
Add minio public_url parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,15 @@ docker run -it \
   -e MINIO__BUCKET=destination-bucket \
   -e MINIO__SECURE=1 \
   -e MINIO__BUCKET_SUBPATH=SubFolder \
+  -e MINIO__PUBLIC_URL="https://my-minio-server.com" \
   lutraconsulting/mergin-media-sync python3 media_sync_daemon.py
 ```
 
 **Please note double underscore `__` is used to separate [config](config.yaml.default) group and item.**
 
 The specification of `MINIO__BUCKET_SUBPATH` is optional and can be skipped if the files should be stored directly in `MINIO__BUCKET`.
+
+The specification of `MINIO__PUBLIC_URL` is optional and can be used if the public URL to access files is different from the one specified in `MINIO__ENDPOINT` (e.g. when using a reverse proxy). If not specified, the value of `MINIO__ENDPOINT` will be used as the base URL for accessing files.
 
 #### Using Google Drive backend
 For setup instructions and more details, please refer to our [Google Drive guide](./docs/google-drive-setup.md).

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -23,6 +23,7 @@ minio:
   secure: false
   region:
   bucket_subpath:
+  public_url:
 
 google_drive:
   service_account_file: 

--- a/drivers.py
+++ b/drivers.py
@@ -96,14 +96,15 @@ class MinioDriver(Driver):
                 self.client.make_bucket(self.bucket)
 
             self.bucket_subpath = None
-            if hasattr(config.minio, "bucket_subpath"):
-                if config.minio.bucket_subpath:
-                    self.bucket_subpath = config.minio.bucket_subpath
+            if hasattr(config.minio, "bucket_subpath") and config.minio.bucket_subpath:
+                self.bucket_subpath = config.minio.bucket_subpath
 
             # construct base url for bucket
             scheme = "https://" if config.as_bool("minio.secure") else "http://"
 
-            if config.minio.region and "amazonaws" in config.minio.endpoint.lower():
+            if hasattr(config.minio, "public_url") and config.minio.public_url:
+                self.base_url = config.minio.public_url.rstrip("/")
+            elif config.minio.region and "amazonaws" in config.minio.endpoint.lower():
                 self.base_url = (
                     f"{scheme}{self.bucket}.s3.{config.minio.region}.amazonaws.com"
                 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -49,6 +49,7 @@ def setup_config():
             "MINIO__BUCKET_SUBPATH": "",
             "MINIO__SECURE": False,
             "MINIO__REGION": "",
+            "MINIO__PUBLIC_URL": ""
         }
     )
 


### PR DESCRIPTION
The specification of `MINIO__PUBLIC_URL` is optional and can be used if the public URL to access files is different from the one specified in `MINIO__ENDPOINT` (e.g. when using a reverse proxy). If not specified, the value of `MINIO__ENDPOINT` will be used as the base URL for accessing files.