### PR TITLE
Fix phantom GeoPackage created from default references config

### DIFF
--- a/config.yaml.default
+++ b/config.yaml.default
@@ -29,11 +29,14 @@ google_drive:
   folder:
   share_with:
 
-references:
-  - file: survey.gpkg
-    table: notes
-    local_path_column: photo
-    driver_path_column: ext_url
+# Reference rewriting is optional and OFF by default. Uncomment and adjust to
+# have media-sync write uploaded file URLs into a GeoPackage table. Leave empty to only copy files.
+references: []
+#references:
+#  - file: survey.gpkg
+#    table: notes
+#    local_path_column: photo
+#    driver_path_column: ext_url
 
 daemon:
   sleep_time: 10

--- a/media_sync.py
+++ b/media_sync.py
@@ -159,11 +159,14 @@ def _update_references(files):
         if not all(reference_config):
             return
 
+        gpkg_path = os.path.join(config.project_working_dir, ref.file)
+        if not os.path.exists(gpkg_path):
+            print(f"Skipping references - file not found in project: {ref.file}")
+            continue
+
         print("Updating references ...")
         try:
-            gpkg_conn = sqlite3.connect(
-                os.path.join(config.project_working_dir, ref.file)
-            )
+            gpkg_conn = sqlite3.connect(gpkg_path)
             gpkg_conn.enable_load_extension(True)
             gpkg_cur = gpkg_conn.cursor()
             gpkg_cur.execute('SELECT load_extension("mod_spatialite")')


### PR DESCRIPTION
Problem

Users running the Docker image without overriding `references` hit a recurring error:

> There are pending changes in the local directory - please review and push manually! {'added': [{'path': 'survey.gpkg', ...size: 0...}]}

`survey.gpkg` doesn't exist in their project - it's a phantom empty file.

Root cause
1. `config.yaml.default` is baked into the docker image as `config.yaml`. This example `references` entry pointing at `survey.gpkg is silently active for everyone.
2. `_update_references`  creates the file if it doesn't exist. The missing `survey.gpkg` was created as an empty file, then flagged as a pending change and blocked every sync cycle.

Fix

- **`config.yaml.default`**: default `references` to `[]`; keep the example commented for documentation. Reference rewriting is now off unless explicitly configured
- **`media_sync.py`**: skip any reference whose file isn't present in the project
